### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 0.1.0 - Unreleased
+## 0.1.0 - 2020-06-04
 
 _Initial implementation._
 
 ### Added
 
-- Add initial MkDocs extension, with support for generating Markdown content by reading and parsing Click commands.
+- Add `::: mkdocs-click` block with `:module:`, `:command:` and `:depth:` options.


### PR DESCRIPTION
## 0.1.0 - 2020-06-04

_Initial implementation._

### Added

- Add `::: mkdocs-click` block with `:module:`, `:command:` and `:depth:` options.
