### PR TITLE
Markup options in a table format

### DIFF
--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -130,13 +130,12 @@ def _make_options(ctx: click.Context) -> Iterator[str]:
 
     yield "**Options:**"
     yield ""
-    yield "| Option | Type | Description | Required | Default |"
-    yield "| ------ | ---- | ----------- | -------- | ------- |"
+    yield "| Name | Type | Description | Default |"
+    yield "| ------ | ---- | ----------- | ------- |"
     for param in params[:-1]:
         options = f"{', '.join(backquote(param.opts))}{'/{}'.format(', '.join(backquote(param.secondary_opts))) if param.secondary_opts != [] else ''}"  # noqa: E501
         value_type = format_possible_value(param)
         description = param.help if param.help is not None else "No description given"
-        required = "&#x2714;" if param.required else ""
-        default = f"`{param.default}`" if param.default is not None else ""
-        yield f"| {options} | {value_type} | {description} | {required} | {default} |"
+        default = f"`{param.default}`" if param.default is not None else "_required_"
+        yield f"| {options} | {value_type} | {description} | {default} |"
     yield ""

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -28,12 +28,12 @@ Usage:
 cli bar hello [OPTIONS]
 ```
 
-Options:
+**Options:**
 
-```
-  --count INTEGER  Number of greetings.
-  --name TEXT      The person to greet.
-```
+| Option | Description |
+| ------ | ----------- |
+| `--count INTEGER` | Number of greetings. |
+| `--name TEXT` | The person to greet. |
 
 ## foo
 

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -30,10 +30,10 @@ cli bar hello [OPTIONS]
 
 **Options:**
 
-| Option | Type | Description | Required | Default |
-| ------ | ---- | ----------- | -------- | ------- |
-| `--count` | INTEGER | Number of greetings. |  | `1` |
-| `--name` | TEXT | The person to greet. |  |  |
+| Name | Type | Description | Default |
+| ------ | ---- | ----------- | ------- |
+| `--count` | INTEGER | Number of greetings. | `1` |
+| `--name` | TEXT | The person to greet. | _required_ |
 
 ## foo
 

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -30,10 +30,10 @@ cli bar hello [OPTIONS]
 
 **Options:**
 
-| Option | Description |
-| ------ | ----------- |
-| `--count INTEGER` | Number of greetings. |
-| `--name TEXT` | The person to greet. |
+| Option | Type | Description | Required | Default |
+| ------ | ---- | ----------- | -------- | ------- |
+| `--count` | INTEGER | Number of greetings. |  | `1` |
+| `--name` | TEXT | The person to greet. |  |  |
 
 ## foo
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -28,12 +28,11 @@ HELLO_EXPECTED = dedent(
     hello [OPTIONS]
     ```
 
-    Options:
+    **Options:**
 
-    ```
-      -d, --debug TEXT  Include debug output
-    ```
-
+    | Option | Description |
+    | ------ | ----------- |
+    | `-d, --debug TEXT` | Include debug output |
     """
 ).strip()
 
@@ -90,11 +89,11 @@ def test_custom_multicommand():
         multi hello [OPTIONS]
         ```
 
-        Options:
+        **Options:**
 
-        ```
-          -d, --debug TEXT  Include debug output
-        ```
+        | Option | Description |
+        | ------ | ----------- |
+        | `-d, --debug TEXT` | Include debug output |
         """
     ).lstrip()
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -30,9 +30,9 @@ HELLO_EXPECTED = dedent(
 
     **Options:**
 
-    | Option | Description |
-    | ------ | ----------- |
-    | `-d, --debug TEXT` | Include debug output |
+    | Option | Type | Description | Required | Default |
+    | ------ | ---- | ----------- | -------- | ------- |
+    | `-d`, `--debug` | TEXT | Include debug output |  |  |
     """
 ).strip()
 
@@ -91,9 +91,9 @@ def test_custom_multicommand():
 
         **Options:**
 
-        | Option | Description |
-        | ------ | ----------- |
-        | `-d, --debug TEXT` | Include debug output |
+        | Option | Type | Description | Required | Default |
+        | ------ | ---- | ----------- | -------- | ------- |
+        | `-d`, `--debug` | TEXT | Include debug output |  |  |
         """
     ).lstrip()
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -30,9 +30,9 @@ HELLO_EXPECTED = dedent(
 
     **Options:**
 
-    | Option | Type | Description | Required | Default |
-    | ------ | ---- | ----------- | -------- | ------- |
-    | `-d`, `--debug` | TEXT | Include debug output |  |  |
+    | Name | Type | Description | Default |
+    | ------ | ---- | ----------- | ------- |
+    | `-d`, `--debug` | TEXT | Include debug output | _required_ |
     """
 ).strip()
 
@@ -91,9 +91,9 @@ def test_custom_multicommand():
 
         **Options:**
 
-        | Option | Type | Description | Required | Default |
-        | ------ | ---- | ----------- | -------- | ------- |
-        | `-d`, `--debug` | TEXT | Include debug output |  |  |
+        | Name | Type | Description | Default |
+        | ------ | ---- | ----------- | ------- |
+        | `-d`, `--debug` | TEXT | Include debug output | _required_ |
         """
     ).lstrip()
 


### PR DESCRIPTION
This PR prints CLI options in a rich table format instead of a plain format we see in terminal. In addition to that, the section name "Options:" is made bold in order to be better aligned with [`mkdocstrings`' heading](https://github.com/pawamoy/mkdocstrings/blob/de2ef32e9ccfd2fe59177d5e5bc4d3daf4f20587/src/mkdocstrings/templates/python/material/parameters.html#L1).

**w/o PR:**

<img width="782" alt="スクリーンショット 2020-11-21 2 36 35" src="https://user-images.githubusercontent.com/13291527/99833147-0184a300-2ba5-11eb-98b1-008f6d161d22.png">

**w/ PR:**

<img width="562" alt="スクリーンショット 2020-11-21 2 50 22" src="https://user-images.githubusercontent.com/13291527/99833188-0f3a2880-2ba5-11eb-833f-56a078be7f54.png">

(These are fixed in 6f89573f71a1d410351b25dad258ffa004d21965) <s>Current implementation has the following restrictions, but I suppose most of the use cases don't fall under these situations.

- If any of the help messages starts with a hyphen, the resulting table would not be what users expect.
- If help messages are written in certain languages (Chinese, Japanese and Thai AFAIK), they might contain unwanted whitespaces. I don't think we should care because this could happen in HTML and Markdown in general and is not a critical problem.</s>

Fix #11.
