### PR TITLE
Add fallback in the absence of Python 3 as python

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -5,7 +5,7 @@ BIN="$VENV/bin/"
 
 set -x
 
-python -m venv $VENV
+python -m venv $VENV || python3 -m venv $VENV
 
 ${BIN}pip install -U pip
 ${BIN}pip install -r requirements.txt


### PR DESCRIPTION
While Python 2 has already reached its end of life, `python` still points to Python 2.x in many computers including mine. Since Python 2.x doesn't have `venv`, I added a fallback that explicitly calls `python3`.