### PR TITLE
Make usage heading bold

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ An MkDocs extension to generate documentation for Click command line application
 
 ## Installation
 
-This package is not available on PyPI yet, but you can install it from git:
+Install from PyPI:
 
 ```bash
-pip install git+https://github.com/DataDog/mkdocs-click.git
+pip install mkdocs-click
 ```
 
 ## Quickstart

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -92,7 +92,7 @@ def _make_usage(ctx: click.Context) -> Iterator[str]:
     full_path.reverse()
     usage_snippet = " ".join(full_path) + usage
 
-    yield "**Usage:**"
+    yield "__Usage:__"
     yield ""
     yield "```"
     yield usage_snippet

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -92,7 +92,7 @@ def _make_usage(ctx: click.Context) -> Iterator[str]:
     full_path.reverse()
     usage_snippet = " ".join(full_path) + usage
 
-    yield "Usage:"
+    yield "**Usage:**"
     yield ""
     yield "```"
     yield usage_snippet

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -2,7 +2,7 @@
 
 Main entrypoint for this dummy program
 
-Usage:
+**Usage:**
 
 ```
 cli [OPTIONS] COMMAND [ARGS]...
@@ -12,7 +12,7 @@ cli [OPTIONS] COMMAND [ARGS]...
 
 The bar command
 
-Usage:
+**Usage:**
 
 ```
 cli bar [OPTIONS] COMMAND [ARGS]...
@@ -22,7 +22,7 @@ cli bar [OPTIONS] COMMAND [ARGS]...
 
 Simple program that greets NAME for a total of COUNT times.
 
-Usage:
+**Usage:**
 
 ```
 cli bar hello [OPTIONS]
@@ -37,7 +37,7 @@ Options:
 
 ## foo
 
-Usage:
+**Usage:**
 
 ```
 cli foo [OPTIONS]

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -22,7 +22,7 @@ cli bar [OPTIONS] COMMAND [ARGS]...
 
 Simple program that greets NAME for a total of COUNT times.
 
-**Usage:**
+__Usage:__
 
 ```
 cli bar hello [OPTIONS]
@@ -37,7 +37,7 @@ Options:
 
 ## foo
 
-**Usage:**
+__Usage:__
 
 ```
 cli foo [OPTIONS]

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -22,7 +22,7 @@ HELLO_EXPECTED = dedent(
 
     Hello, world!
 
-    **Usage:**
+    __Usage:__
 
     ```
     hello [OPTIONS]
@@ -74,7 +74,7 @@ def test_custom_multicommand():
 
         Multi help
 
-        **Usage:**
+        __Usage:__
 
         ```
         multi [OPTIONS] COMMAND [ARGS]...
@@ -84,7 +84,7 @@ def test_custom_multicommand():
 
         Hello, world!
 
-        **Usage:**
+        __Usage:__
 
         ```
         multi hello [OPTIONS]

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -22,7 +22,7 @@ HELLO_EXPECTED = dedent(
 
     Hello, world!
 
-    Usage:
+    **Usage:**
 
     ```
     hello [OPTIONS]
@@ -74,7 +74,7 @@ def test_custom_multicommand():
 
         Multi help
 
-        Usage:
+        **Usage:**
 
         ```
         multi [OPTIONS] COMMAND [ARGS]...
@@ -84,7 +84,7 @@ def test_custom_multicommand():
 
         Hello, world!
 
-        Usage:
+        **Usage:**
 
         ```
         multi hello [OPTIONS]


### PR DESCRIPTION
This is a follow-up PR to #12. Usage heading is made bold as well so that usage and options sections have a consistent appearance.