### PR TITLE
Add example docs site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,14 @@ cd mkdocs-click
 scripts/install
 ```
 
+## Example docs site
+
+You can run the example docs site that lives in `example/` locally using:
+
+```bash
+scripts/docs serve
+```
+
 ## Testing and linting
 
 Once dependencies are installed, you can run the test suite using:

--- a/example/index.md
+++ b/example/index.md
@@ -1,0 +1,8 @@
+# Introduction
+
+This demo site shows the rendering of the [MkDocs](https://www.mkdocs.org/) CLI itself through `mkdocs-click`.
+
+::: mkdocs-click
+    :module: mkdocs.__main__
+    :command: cli
+    :depth: 1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+# NOTE: this is not an actual docs site for `mkdocs-click`, but rather a
+# demo site to demonstrate the abilities of `mkdocs-click`.
+site_name: mkdocs-click example
+theme: readthedocs
+
+docs_dir: example
+
+markdown_extensions:
+  - mkdocs-click

--- a/scripts/docs
+++ b/scripts/docs
@@ -1,0 +1,7 @@
+#! /bin/sh -e
+
+BIN="venv/bin/"
+
+set -x
+
+${BIN}mkdocs "$@"


### PR DESCRIPTION
**Description**
Add a local `example` docs site that renders the CLI of `mkdocs` itself through `mkdocs-click`.

**Motivation**
This will make it easier to iterate quickly on `mkdocs-click`.