### PR TITLE
Fix type error on latest mypy

### DIFF
--- a/mkdocs_click/_extension.py
+++ b/mkdocs_click/_extension.py
@@ -3,7 +3,6 @@
 # Licensed under the Apache license (see LICENSE)
 from typing import Any, List, Iterator
 
-from markdown import Markdown
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
@@ -43,7 +42,7 @@ class MKClickExtension(Extension):
     by Markdown documentation generated from the specified Click application.
     """
 
-    def extendMarkdown(self, md: Markdown) -> None:
+    def extendMarkdown(self, md: Any) -> None:
         md.registerExtension(self)
         processor = ClickProcessor(md.parser)
         md.preprocessors.register(processor, "mk_click", 141)


### PR DESCRIPTION
Prompted by CI failures across the board that show:

```
+ venv/bin/mypy mkdocs_click tests
mkdocs_click/_extension.py:48: error: "Markdown" has no attribute "parser"
mkdocs_click/_extension.py:49: error: "Markdown" has no attribute "preprocessors"
Found 2 errors in 1 file (checked 15 source files)
```