### PR TITLE
Pin dev dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ twine
 wheel
 
 # Linters
-black
-flake8
-mypy
+black==20.8b1
+flake8==3.8.4
+mypy==0.790
 
 # Testing
-mock==4.*
-pytest==5.*
-pytest-cov
+mock==4.0.2
+pytest==5.4.3
+pytest-cov==2.10.1


### PR DESCRIPTION
**Motivation**
By strictly pinning dev deps, we can prevent issues like #16 from happening again without notice.