### PR TITLE
Properly pin `click` and `markdown` dependencies to current major versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     author_email="packages@datadoghq.com",
     license="Apache",
     packages=["mkdocs_click"],
-    install_requires=["click", "markdown"],
+    install_requires=["click==7.*", "markdown==3.*"],
     python_requires=">=3.7",
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
**Motivation**
Prevent breakage due to `click` or `markdown` bumping major versions. If that happens, users may start noticing and letting us know, and we could then look at adding support for 8.* or 4.*.