### PR TITLE
Use "python3 as the executable when installing deps

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -5,7 +5,7 @@ BIN="$VENV/bin/"
 
 set -x
 
-python -m venv $VENV
+python3 -m venv $VENV
 
 ${BIN}pip install -U pip
 ${BIN}pip install -r requirements.txt


### PR DESCRIPTION
Alternative to #13

Some contributors may have `python` referring to Python 2. Most people should have `python3` referring to a proper Python 3.x executable (even pyenv users), so let's use that instead.
