### PR TITLE
Version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.2.0 - 2020-12-09
+
+### Added
+
+- Add `:prog_name:` option to allow overriding the name of the CLI program. (Pull #8, contributed by @frankier.)
+- Add official support for Python 3.9. (Pull #20)
+
+### Fixed
+
+- Properly pin `click==7.*` and `markdown==3.*`. (Pull #19)
+
 ## 0.1.1 - 2020-06-05
 
 ### Fixed

--- a/mkdocs_click/__version__.py
+++ b/mkdocs_click/__version__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under the Apache license (see LICENSE)
-__version__ = "0.1.1"
+__version__ = "0.2.0"


### PR DESCRIPTION
Changelog source: https://github.com/DataDog/mkdocs-click/compare/0.1.1...7a6fd098

`integrations-core` notes: we are properly pinning to `0.1.*`, so this shouldn't affect us in any way. We can look at upgrading once this release is out.

https://github.com/DataDog/integrations-core/blob/1d69a6ef48858b50bad753eea57c4ca5ab85a2e1/tox.ini#L34-L35

## 0.2.0 - 2020-12-09

### Added

- Add `:prog_name:` option to allow overriding the name of the CLI program. (Pull #8, contributed by @frankier.)
- Add official support for Python 3.9. (Pull #20)

### Fixed

- Properly pin `click==7.*` and `markdown==3.*`. (Pull #19)
