### PR TITLE
Use prog_name for usage

### DIFF
--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -1,11 +1,9 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under the Apache license (see LICENSE)
-from typing import Iterator, List, Optional, cast
+from typing import Iterator, List, cast
 
 import click
-
-from ._exceptions import MkDocsClickException
 
 
 def make_command_docs(prog_name: str, command: click.BaseCommand, level: int = 0) -> Iterator[str]:
@@ -18,7 +16,7 @@ def _recursively_make_command_docs(
     prog_name: str, command: click.BaseCommand, parent: click.Context = None, level: int = 0
 ) -> Iterator[str]:
     """Create the raw Markdown lines for a command and its sub-commands."""
-    ctx = click.Context(cast(click.Command, command), parent=parent)
+    ctx = click.Context(cast(click.Command, command), info_name=prog_name, parent=parent)
 
     yield from _make_title(prog_name, level)
     yield from _make_description(ctx)
@@ -79,23 +77,10 @@ def _make_usage(ctx: click.Context) -> Iterator[str]:
     formatter.write_usage(ctx.command_path, " ".join(pieces), prefix="")
     usage = formatter.getvalue().rstrip("\n")
 
-    # Generate the full usage string based on parents if any, i.e. `root sub1 sub2 ...`.
-    full_path = []
-    current: Optional[click.Context] = ctx
-    while current is not None:
-        name = current.command.name
-        if name is None:
-            raise MkDocsClickException(f"command {current.command} has no `name`")
-        full_path.append(name)
-        current = current.parent
-
-    full_path.reverse()
-    usage_snippet = " ".join(full_path) + usage
-
     yield "Usage:"
     yield ""
     yield "```"
-    yield usage_snippet
+    yield usage
     yield "```"
     yield ""
 

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -5,6 +5,8 @@ from typing import Iterator, List, cast
 
 import click
 
+from ._exceptions import MkDocsClickException
+
 
 def make_command_docs(
     prog_name: str, command: click.BaseCommand, level: int = 0, style: str = "plain"

--- a/mkdocs_click/_extension.py
+++ b/mkdocs_click/_extension.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under the Apache license (see LICENSE)
-from typing import Any, List, Iterator
+from typing import Any, Iterator, List
 
 from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
@@ -19,10 +19,12 @@ def replace_command_docs(**options: Any) -> Iterator[str]:
 
     module = options["module"]
     command = options["command"]
-    prog_name = options.get("prog_name", command)
+    prog_name = options.get("prog_name", None)
     depth = int(options.get("depth", 0))
 
     command_obj = load_command(module, command)
+
+    prog_name = prog_name or command_obj.name or command
 
     return make_command_docs(prog_name=prog_name, command=command_obj, level=depth)
 

--- a/tests/app/cli.py
+++ b/tests/app/cli.py
@@ -3,7 +3,6 @@
 # Licensed under the Apache license (see LICENSE)
 import click
 
-
 NOT_A_COMMAND = "not-a-command"
 
 
@@ -19,6 +18,11 @@ def cli():
     """Main entrypoint for this dummy program"""
 
 
+@click.group(name="cli")
+def cli_named():
+    """Main entrypoint for this dummy program"""
+
+
 @click.command()
 def foo():  # No description
     pass  # pragma: no cover
@@ -30,5 +34,22 @@ def bar():
 
 
 bar.add_command(hello)
+
 cli.add_command(foo)
 cli.add_command(bar)
+
+cli_named.add_command(foo)
+cli_named.add_command(bar)
+
+
+class MultiCLI(click.MultiCommand):
+    def list_commands(self, ctx):
+        return ["foo", "bar"]
+
+    def get_command(self, ctx, name):
+        cmds = {"foo": foo, "bar": bar}
+        return cmds.get(name, None)
+
+
+multi_named = MultiCLI(name="multi", help="Main entrypoint for this dummy program")
+multi = MultiCLI(help="Main entrypoint for this dummy program")

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4,10 +4,9 @@
 from pathlib import Path
 from textwrap import dedent
 
+import mkdocs_click
 import pytest
 from markdown import Markdown
-
-import mkdocs_click
 
 EXPECTED = (Path(__file__).parent / "app" / "expected.md").read_text()
 
@@ -44,7 +43,7 @@ def test_prog_name():
         """
     )
 
-    expected = EXPECTED.replace("# cli", "# custom")
+    expected = EXPECTED.replace("cli", "custom")
 
     assert md.convert(source) == md.convert(expected)
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4,39 +4,36 @@
 from pathlib import Path
 from textwrap import dedent
 
-import mkdocs_click
 import pytest
 from markdown import Markdown
+
+import mkdocs_click
 
 EXPECTED = (Path(__file__).parent / "app" / "expected.md").read_text()
 
 
 @pytest.mark.parametrize(
-    "attr",
+    "command, expected_name",
     [
-        pytest.param(("cli", "cli"), id="cli-simple"),
-        pytest.param(("cli_named", "cli"), id="cli-explicit-name"),
-        pytest.param(("multi_named", "multi"), id="multi-explicit-name"),
-        pytest.param(("multi", "multi"), id="no-name"),
+        pytest.param("cli", "cli", id="cli-simple"),
+        pytest.param("cli_named", "cli", id="cli-explicit-name"),
+        pytest.param("multi_named", "multi", id="multi-explicit-name"),
+        pytest.param("multi", "multi", id="no-name"),
     ],
 )
-def test_extension(attr):
+def test_extension(command, expected_name):
     """
     Markdown output for a relatively complex Click application is correct.
     """
-    (command, expected_name) = attr
-
     md = Markdown(extensions=[mkdocs_click.makeExtension()])
 
     source = dedent(
-        """
+        f"""
         ::: mkdocs-click
             :module: tests.app.cli
-            :command: {{cli}}
+            :command: {command}
         """
     )
-
-    source = source.replace("{{cli}}", command)
 
     expected = EXPECTED.replace("cli", expected_name)
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -11,21 +11,36 @@ from markdown import Markdown
 EXPECTED = (Path(__file__).parent / "app" / "expected.md").read_text()
 
 
-def test_extension():
+@pytest.mark.parametrize(
+    "attr",
+    [
+        pytest.param(("cli", "cli"), id="cli-simple"),
+        pytest.param(("cli_named", "cli"), id="cli-explicit-name"),
+        pytest.param(("multi_named", "multi"), id="multi-explicit-name"),
+        pytest.param(("multi", "multi"), id="no-name"),
+    ],
+)
+def test_extension(attr):
     """
     Markdown output for a relatively complex Click application is correct.
     """
+    (command, expected_name) = attr
+
     md = Markdown(extensions=[mkdocs_click.makeExtension()])
 
     source = dedent(
         """
         ::: mkdocs-click
             :module: tests.app.cli
-            :command: cli
+            :command: {{cli}}
         """
     )
 
-    assert md.convert(source) == md.convert(EXPECTED)
+    source = source.replace("{{cli}}", command)
+
+    expected = EXPECTED.replace("cli", expected_name)
+
+    assert md.convert(source) == md.convert(expected)
 
 
 def test_prog_name():

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -6,7 +6,6 @@ from textwrap import dedent
 import click
 import pytest
 from mkdocs_click._docs import make_command_docs
-from mkdocs_click._exceptions import MkDocsClickException
 
 
 @click.command()
@@ -60,7 +59,14 @@ class MultiCLI(click.MultiCommand):
         return hello
 
 
-def test_custom_multicommand():
+@pytest.mark.parametrize(
+    "multi",
+    [
+        pytest.param(MultiCLI("multi", help="Multi help"), id="explicit-name"),
+        pytest.param(MultiCLI(help="Multi help"), id="no-name"),
+    ],
+)
+def test_custom_multicommand(multi):
     """
     Custom `MultiCommand` objects are supported (i.e. not just `Group` multi-commands).
     """
@@ -99,10 +105,3 @@ def test_custom_multicommand():
 
     output = "\n".join(make_command_docs("multi", multi))
     assert output == expected
-
-
-def test_custom_multicommand_name():
-    """Custom multi commands must be given a name."""
-    multi = MultiCLI()
-    with pytest.raises(MkDocsClickException):
-        list(make_command_docs("multi", multi))

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 
 import click
 import pytest
+
 from mkdocs_click._docs import make_command_docs
 from mkdocs_click._exceptions import MkDocsClickException
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 
 import click
 import pytest
-
 from mkdocs_click._docs import make_command_docs
 from mkdocs_click._exceptions import MkDocsClickException
 
@@ -50,7 +49,7 @@ def test_depth():
 
 def test_prog_name():
     output = "\n".join(make_command_docs("hello-world", hello)).strip()
-    assert output == HELLO_EXPECTED.replace("# hello", "# hello-world")
+    assert output == HELLO_EXPECTED.replace("hello", "hello-world")
 
 
 class MultiCLI(click.MultiCommand):

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 import click
 import pytest
 from mkdocs_click._docs import make_command_docs
+from mkdocs_click._exceptions import MkDocsClickException
 
 
 @click.command()
@@ -80,7 +81,7 @@ HELLO_TABLE_EXPECTED = dedent(
     Usage:
 
     ```
-    hello-table [OPTIONS]
+    hello [OPTIONS]
     ```
 
     Options:
@@ -118,7 +119,7 @@ HELLO_TABLE_MINIMAL_EXPECTED = dedent(
     Usage:
 
     ```
-    hello-minimal [OPTIONS]
+    hello [OPTIONS]
     ```
 
     Options:


### PR DESCRIPTION
This PR ensures the `prog_name` (introduced by #8 and initially requested in #6) is also used in the usage sections.

This is achieved by properly setting the `info_name` for the [click.Context](https://click.palletsprojects.com/en/7.x/api/#context) used during documentation rendering.  Setting the `info_name` allows click to properly populate the `ctx.command_path` property and thus `_docs.py line 77` now actually combines the command path and the pieces correctly. In the previous version `ctx.command_path` was always empty. This makes the custom command path building logic obsolete.

Now as a side effect this produces one failing test:

```python
    def test_custom_multicommand_name():
        """Custom multi commands must be given a name."""
        multi = MultiCLI()
        with pytest.raises(MkDocsClickException):
>           list(make_command_docs("multi", multi))
E           Failed: DID NOT RAISE <class 'mkdocs_click._exceptions.MkDocsClickException'>

tests/unit/test_docs.py:108: Failed
```

The test obviously fails as the exception is not raised anymore in the usage portion. Now I am unsure if this test can be removed or not. For entrypoint level `MultiCli()` commands we get a guaranteed name populated either through the `prog_name` option directly or indirectly via the `command` option. This is regardless whether the actual `MultiCli` was instantiated with a name or not.

Now while I strongly believe this makes it impossible for entrypoint level multi commands to cause any name issues I am not a 100% sure about multi commands which are sub commands. If such a sub command is possible then a check+raise would have to be added to the recursive call.
```python
    for command in sorted(subcommands, key=lambda cmd: cmd.name):
        yield from _recursively_make_command_docs(command.name, command, parent=ctx, level=level + 1)
```
Here `command.name` is invoked. Now from what I can see and know about click it is not possible to add a multi command to a click group without assigning a name to it. e.g., [add_command](https://click.palletsprojects.com/en/7.x/api/#click.Group.add_command) will raise a `TypeError` if both the function input `name` and input `cmd.name` are `None`.

Please verify the correctness of my "findings" and advise if the failing test can be removed and the PR is ok as is or if it is possible to get a sub command without name. Once you have verified this feel free to remove the test or apply changes yourself or I can also do so myself if you give notify me with a comment.


