### PR TITLE
Add table style for option formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,4 @@ Options:
 - `command`: name of the command object.
 - `prog_name`: _(Optional, default: same as `command`)_ the name to display for the command.
 - `depth`: _(Optional, default: `0`)_ Offset to add when generating headers.
+- `option-style`: _(Optional, default: `plain`)_ style for the option section. The possible choices are `plain` and `table`.

--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ Options:
 - `command`: name of the command object.
 - `prog_name`: _(Optional, default: same as `command`)_ the name to display for the command.
 - `depth`: _(Optional, default: `0`)_ Offset to add when generating headers.
-- `option-style`: _(Optional, default: `plain`)_ style for the option section. The possible choices are `plain` and `table`.
+- `style`: _(Optional, default: `plain`)_ style for the options section. The possible choices are `plain` and `table`.

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -1,21 +1,27 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under the Apache license (see LICENSE)
-from typing import Iterator, List, Optional, cast
+from typing import Iterable, Iterator, List, Optional, cast
 
 import click
 
 from ._exceptions import MkDocsClickException
 
 
-def make_command_docs(prog_name: str, command: click.BaseCommand, level: int = 0) -> Iterator[str]:
+def make_command_docs(
+    prog_name: str, command: click.BaseCommand, level: int = 0, styles: dict = {"option": "plain"}
+) -> Iterator[str]:
     """Create the Markdown lines for a command and its sub-commands."""
-    for line in _recursively_make_command_docs(prog_name, command, level=level):
+    for line in _recursively_make_command_docs(prog_name, command, level=level, styles=styles):
         yield line.replace("\b", "")
 
 
 def _recursively_make_command_docs(
-    prog_name: str, command: click.BaseCommand, parent: click.Context = None, level: int = 0
+    prog_name: str,
+    command: click.BaseCommand,
+    parent: click.Context = None,
+    level: int = 0,
+    styles: dict = {"option": "plain"},
 ) -> Iterator[str]:
     """Create the raw Markdown lines for a command and its sub-commands."""
     ctx = click.Context(cast(click.Command, command), parent=parent)
@@ -23,7 +29,7 @@ def _recursively_make_command_docs(
     yield from _make_title(prog_name, level)
     yield from _make_description(ctx)
     yield from _make_usage(ctx)
-    yield from _make_options(ctx)
+    yield from _make_options(ctx, styles["option"])
 
     subcommands = _get_sub_commands(ctx.command, ctx)
 
@@ -100,19 +106,59 @@ def _make_usage(ctx: click.Context) -> Iterator[str]:
     yield ""
 
 
-def _make_options(ctx: click.Context) -> Iterator[str]:
+def _make_options(ctx: click.Context, style: str = "plain") -> Iterator[str]:
     """Create the Markdown lines describing the options for the command."""
-    formatter = ctx.make_formatter()
-    click.Command.format_options(ctx.command, ctx, formatter)
-    # First line is redundant "Options"
-    # Last line is `--help`
-    option_lines = formatter.getvalue().splitlines()[1:-1]
-    if not option_lines:
-        return
 
-    yield "Options:"
-    yield ""
-    yield "```"
-    yield from option_lines
-    yield "```"
-    yield ""
+    def backquote(opts: Iterable[str]) -> List[str]:
+        return [f"`{opt}`" for opt in opts]
+
+    def format_possible_value(opt: click.Option) -> str:
+        param_type = opt.type
+
+        if isinstance(param_type, click.Choice):
+            return f"{param_type.name.upper()} ({' &#x7C; '.join(backquote(param_type.choices))})"
+        elif isinstance(param_type, click.DateTime):
+            return f"{param_type.name.upper()} ({' &#x7C; '.join(backquote(param_type.formats))})"
+        elif isinstance(param_type, (click.IntRange, click.FloatRange)):
+            if param_type.min is not None and param_type.max is not None:
+                return f"{param_type.name.upper()} (between `{param_type.min}` and `{param_type.max}`)"
+            elif param_type.min is not None:
+                return f"{param_type.name.upper()} (`{param_type.min}` and above)"
+            else:
+                return f"{param_type.name.upper()} (`{param_type.max}` and below)"
+        else:
+            return param_type.name.upper()
+
+    if style == "plain":
+        formatter = ctx.make_formatter()
+        click.Command.format_options(ctx.command, ctx, formatter)
+        # First line is redundant "Options"
+        # Last line is `--help`
+        option_lines = formatter.getvalue().splitlines()[1:-1]
+        if not option_lines:
+            return
+
+        yield "__Options:__"
+        yield ""
+        yield "```"
+        yield from option_lines
+        yield "```"
+        yield ""
+    elif style == "table":
+        params = [param for param in ctx.command.get_params(ctx) if isinstance(param, click.Option)]
+        if params[0].opts[0] == "--help":
+            return
+
+        yield "__Options:__"
+        yield ""
+        yield "| Name | Type | Description | Default |"
+        yield "| ------ | ---- | ----------- | ------- |"
+        for param in params[:-1]:
+            options = f"{', '.join(backquote(param.opts))}{'/{}'.format(', '.join(backquote(param.secondary_opts))) if param.secondary_opts != [] else ''}"  # noqa: E501
+            value_type = format_possible_value(param)
+            description = param.help if param.help is not None else "No description given"
+            default = f"`{param.default}`" if param.default is not None else "_required_"
+            yield f"| {options} | {value_type} | {description} | {default} |"
+        yield ""
+    else:
+        raise ValueError(f"{style} is not a valid option style, which must be either 'plain' or 'table'.")

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -9,19 +9,15 @@ from ._exceptions import MkDocsClickException
 
 
 def make_command_docs(
-    prog_name: str, command: click.BaseCommand, level: int = 0, styles: dict = {"option": "plain"}
+    prog_name: str, command: click.BaseCommand, level: int = 0, style: str = "plain"
 ) -> Iterator[str]:
     """Create the Markdown lines for a command and its sub-commands."""
-    for line in _recursively_make_command_docs(prog_name, command, level=level, styles=styles):
+    for line in _recursively_make_command_docs(prog_name, command, level=level, style=style):
         yield line.replace("\b", "")
 
 
 def _recursively_make_command_docs(
-    prog_name: str,
-    command: click.BaseCommand,
-    parent: click.Context = None,
-    level: int = 0,
-    styles: dict = {"option": "plain"},
+    prog_name: str, command: click.BaseCommand, parent: click.Context = None, level: int = 0, style: str = "plain"
 ) -> Iterator[str]:
     """Create the raw Markdown lines for a command and its sub-commands."""
     ctx = click.Context(cast(click.Command, command), parent=parent)
@@ -29,7 +25,7 @@ def _recursively_make_command_docs(
     yield from _make_title(prog_name, level)
     yield from _make_description(ctx)
     yield from _make_usage(ctx)
-    yield from _make_options(ctx, styles["option"])
+    yield from _make_options(ctx, style)
 
     subcommands = _get_sub_commands(ctx.command, ctx)
 
@@ -109,56 +105,70 @@ def _make_usage(ctx: click.Context) -> Iterator[str]:
 def _make_options(ctx: click.Context, style: str = "plain") -> Iterator[str]:
     """Create the Markdown lines describing the options for the command."""
 
+    if style == "plain":
+        return _make_plain_options(ctx)
+    elif style == "table":
+        return _make_table_options(ctx)
+    else:
+        raise MkDocsClickException(f"{style} is not a valid option style, which must be either 'plain' or 'table'.")
+
+
+def _make_plain_options(ctx: click.Context) -> Iterator[str]:
+    """Create the plain style options description."""
+    formatter = ctx.make_formatter()
+    click.Command.format_options(ctx.command, ctx, formatter)
+    # First line is redundant "Options"
+    # Last line is `--help`
+    option_lines = formatter.getvalue().splitlines()[1:-1]
+    if not option_lines:
+        return
+
+    yield "Options:"
+    yield ""
+    yield "```"
+    yield from option_lines
+    yield "```"
+    yield ""
+
+
+def _make_table_options(ctx: click.Context) -> Iterator[str]:
+    """Create the table style options description."""
+
     def backquote(opts: Iterable[str]) -> List[str]:
         return [f"`{opt}`" for opt in opts]
 
     def format_possible_value(opt: click.Option) -> str:
         param_type = opt.type
+        display_name = param_type.name
 
+        # TODO: remove type-ignore comments once python/typeshed#4813 gets merged.
         if isinstance(param_type, click.Choice):
-            return f"{param_type.name.upper()} ({' &#x7C; '.join(backquote(param_type.choices))})"
+            return f"{display_name} ({' &#x7C; '.join(backquote(param_type.choices))})"
         elif isinstance(param_type, click.DateTime):
-            return f"{param_type.name.upper()} ({' &#x7C; '.join(backquote(param_type.formats))})"
+            return f"{display_name} ({' &#x7C; '.join(backquote(param_type.formats))})"  # type: ignore[attr-defined]
         elif isinstance(param_type, (click.IntRange, click.FloatRange)):
-            if param_type.min is not None and param_type.max is not None:
-                return f"{param_type.name.upper()} (between `{param_type.min}` and `{param_type.max}`)"
-            elif param_type.min is not None:
-                return f"{param_type.name.upper()} (`{param_type.min}` and above)"
+            if param_type.min is not None and param_type.max is not None:  # type: ignore[union-attr]
+                return f"{display_name} (between `{param_type.min}` and `{param_type.max}`)"  # type: ignore[union-attr]
+            elif param_type.min is not None:  # type: ignore[union-attr]
+                return f"{display_name} (`{param_type.min}` and above)"  # type: ignore[union-attr]
             else:
-                return f"{param_type.name.upper()} (`{param_type.max}` and below)"
+                return f"{display_name} (`{param_type.max}` and below)"  # type: ignore[union-attr]
         else:
-            return param_type.name.upper()
+            return display_name
 
-    if style == "plain":
-        formatter = ctx.make_formatter()
-        click.Command.format_options(ctx.command, ctx, formatter)
-        # First line is redundant "Options"
-        # Last line is `--help`
-        option_lines = formatter.getvalue().splitlines()[1:-1]
-        if not option_lines:
-            return
+    params = [param for param in ctx.command.get_params(ctx) if isinstance(param, click.Option)]
+    if params[0].opts[0] == "--help":
+        return
 
-        yield "__Options:__"
-        yield ""
-        yield "```"
-        yield from option_lines
-        yield "```"
-        yield ""
-    elif style == "table":
-        params = [param for param in ctx.command.get_params(ctx) if isinstance(param, click.Option)]
-        if params[0].opts[0] == "--help":
-            return
-
-        yield "__Options:__"
-        yield ""
-        yield "| Name | Type | Description | Default |"
-        yield "| ------ | ---- | ----------- | ------- |"
-        for param in params[:-1]:
-            options = f"{', '.join(backquote(param.opts))}{'/{}'.format(', '.join(backquote(param.secondary_opts))) if param.secondary_opts != [] else ''}"  # noqa: E501
-            value_type = format_possible_value(param)
-            description = param.help if param.help is not None else "No description given"
-            default = f"`{param.default}`" if param.default is not None else "_required_"
-            yield f"| {options} | {value_type} | {description} | {default} |"
-        yield ""
-    else:
-        raise ValueError(f"{style} is not a valid option style, which must be either 'plain' or 'table'.")
+    yield "Options:"
+    yield ""
+    yield "| Name | Type | Description | Default |"
+    yield "| ------ | ---- | ----------- | ------- |"
+    for param in params[:-1]:
+        names = ", ".join(backquote(param.opts))
+        names_negeation = f" / {', '.join(backquote(param.secondary_opts))}" if param.secondary_opts != [] else ""
+        value_type = format_possible_value(param)
+        description = param.help if param.help is not None else "No description given"
+        default = f"`{param.default}`" if param.default is not None else "_required_"
+        yield f"| {names}{names_negeation} | {value_type} | {description} | {default} |"
+    yield ""

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -168,7 +168,7 @@ def _make_table_options(ctx: click.Context) -> Iterator[str]:
         names = ", ".join(backquote(param.opts))
         names_negeation = f" / {', '.join(backquote(param.secondary_opts))}" if param.secondary_opts != [] else ""
         value_type = format_possible_value(param)
-        description = param.help if param.help is not None else "No description given"
+        description = param.help if param.help is not None else "N/A"
         default = f"`{param.default}`" if param.default is not None else "_required_"
         yield f"| {names}{names_negeation} | {value_type} | {description} | {default} |"
     yield ""

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -166,9 +166,9 @@ def _make_table_options(ctx: click.Context) -> Iterator[str]:
     yield "| ------ | ---- | ----------- | ------- |"
     for param in params[:-1]:
         names = ", ".join(backquote(param.opts))
-        names_negeation = f" / {', '.join(backquote(param.secondary_opts))}" if param.secondary_opts != [] else ""
+        names_negation = f" / {', '.join(backquote(param.secondary_opts))}" if param.secondary_opts != [] else ""
         value_type = format_possible_value(param)
         description = param.help if param.help is not None else "N/A"
         default = f"`{param.default}`" if param.default is not None else "_required_"
-        yield f"| {names}{names_negeation} | {value_type} | {description} | {default} |"
+        yield f"| {names}{names_negation} | {value_type} | {description} | {default} |"
     yield ""

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -161,14 +161,12 @@ def _make_table_options(ctx: click.Context) -> Iterator[str]:
             return display_name
 
     params = [param for param in ctx.command.get_params(ctx) if isinstance(param, click.Option)]
-    if params[0].opts[0] == "--help":
-        return
 
     yield "Options:"
     yield ""
     yield "| Name | Type | Description | Default |"
     yield "| ------ | ---- | ----------- | ------- |"
-    for param in params[:-1]:
+    for param in params:
         names = ", ".join(backquote(param.opts))
         names_negation = f" / {', '.join(backquote(param.secondary_opts))}" if param.secondary_opts != [] else ""
         value_type = format_possible_value(param)

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -110,7 +110,7 @@ def _make_options(ctx: click.Context, style: str = "plain") -> Iterator[str]:
     elif style == "table":
         return _make_table_options(ctx)
     else:
-        raise MkDocsClickException(f"{style} is not a valid option style, which must be either 'plain' or 'table'.")
+        raise MkDocsClickException(f"{style} is not a valid option style, which must be either `plain` or `table`.")
 
 
 def _make_plain_options(ctx: click.Context) -> Iterator[str]:

--- a/mkdocs_click/_extension.py
+++ b/mkdocs_click/_extension.py
@@ -21,11 +21,11 @@ def replace_command_docs(**options: Any) -> Iterator[str]:
     command = options["command"]
     prog_name = options.get("prog_name", command)
     depth = int(options.get("depth", 0))
-    styles = {"option": options.get("option-style", "plain")}
+    style = options.get("option-style", "plain")
 
     command_obj = load_command(module, command)
 
-    return make_command_docs(prog_name=prog_name, command=command_obj, level=depth, styles=styles)
+    return make_command_docs(prog_name=prog_name, command=command_obj, level=depth, style=style)
 
 
 class ClickProcessor(Preprocessor):

--- a/mkdocs_click/_extension.py
+++ b/mkdocs_click/_extension.py
@@ -21,10 +21,11 @@ def replace_command_docs(**options: Any) -> Iterator[str]:
     command = options["command"]
     prog_name = options.get("prog_name", command)
     depth = int(options.get("depth", 0))
+    styles = {"option": options.get("option-style", "plain")}
 
     command_obj = load_command(module, command)
 
-    return make_command_docs(prog_name=prog_name, command=command_obj, level=depth)
+    return make_command_docs(prog_name=prog_name, command=command_obj, level=depth, styles=styles)
 
 
 class ClickProcessor(Preprocessor):

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -28,7 +28,7 @@ Usage:
 cli bar hello [OPTIONS]
 ```
 
-Options:
+__Options:__
 
 ```
   --count INTEGER  Number of greetings.

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -28,7 +28,7 @@ Usage:
 cli bar hello [OPTIONS]
 ```
 
-__Options:__
+Options:
 
 ```
   --count INTEGER  Number of greetings.

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -28,7 +28,7 @@ HELLO_EXPECTED = dedent(
     hello [OPTIONS]
     ```
 
-    Options:
+    __Options:__
 
     ```
       -d, --debug TEXT  Include debug output
@@ -51,6 +51,80 @@ def test_depth():
 def test_prog_name():
     output = "\n".join(make_command_docs("hello-world", hello)).strip()
     assert output == HELLO_EXPECTED.replace("# hello", "# hello-world")
+
+
+def test_make_command_docs_invalid():
+    with pytest.raises(
+        ValueError, match="invalid is not a valid option style, which must be either 'plain' or 'table'."
+    ):
+        "\n".join(make_command_docs("hello", hello, styles={"option": "invalid"})).strip()
+
+
+@click.command()
+@click.option("-d", "--debug", help="Include debug output")
+@click.option("--choice", type=click.Choice(["foo", "bar"]), default="foo")
+@click.option("--date", type=click.DateTime(["%Y-%m-%d"]))
+@click.option("--range-a", type=click.FloatRange(0, 1), default=0)
+@click.option("--range-b", type=click.FloatRange(0))
+@click.option("--range-c", type=click.FloatRange(None, 1), default=0)
+def hello_table():
+    """Hello, world!"""
+
+
+HELLO_TABLE_EXPECTED = dedent(
+    """
+    # hello
+
+    Hello, world!
+
+    Usage:
+
+    ```
+    hello-table [OPTIONS]
+    ```
+
+    __Options:__
+
+    | Name | Type | Description | Default |
+    | ------ | ---- | ----------- | ------- |
+    | `-d`, `--debug` | TEXT | Include debug output | _required_ |
+    | `--choice` | CHOICE (`foo` &#x7C; `bar`) | No description given | `foo` |
+    | `--date` | DATETIME (`%Y-%m-%d`) | No description given | _required_ |
+    | `--range-a` | FLOAT RANGE (between `0` and `1`) | No description given | `0` |
+    | `--range-b` | FLOAT RANGE (`0` and above) | No description given | _required_ |
+    | `--range-c` | FLOAT RANGE (`1` and below) | No description given | `0` |
+    """
+).strip()
+
+
+def test_make_command_docs_table():
+    output = "\n".join(make_command_docs("hello", hello_table, styles={"option": "table"})).strip()
+    assert output == HELLO_TABLE_EXPECTED
+
+
+@click.command()
+def hello_only_help():
+    """Hello, world!"""
+
+
+HELLO_ONLY_HELP_EXPECTED = dedent(
+    """
+    # hello
+
+    Hello, world!
+
+    Usage:
+
+    ```
+    hello-only-help [OPTIONS]
+    ```
+    """
+).strip()
+
+
+def test_make_command_docs_only_help():
+    output = "\n".join(make_command_docs("hello", hello_only_help, styles={"option": "table"})).strip()
+    assert output == HELLO_ONLY_HELP_EXPECTED
 
 
 class MultiCLI(click.MultiCommand):
@@ -90,7 +164,7 @@ def test_custom_multicommand():
         multi hello [OPTIONS]
         ```
 
-        Options:
+        __Options:__
 
         ```
           -d, --debug TEXT  Include debug output

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -67,6 +67,7 @@ def test_make_command_docs_invalid():
 @click.option("--range-a", type=click.FloatRange(0, 1), default=0)
 @click.option("--range-b", type=click.FloatRange(0))
 @click.option("--range-c", type=click.FloatRange(None, 1), default=0)
+@click.option("--flag/--no-flag")
 def hello_table():
     """Hello, world!"""
 
@@ -93,6 +94,7 @@ HELLO_TABLE_EXPECTED = dedent(
     | `--range-a` | float range (between `0` and `1`) | No description given | `0` |
     | `--range-b` | float range (`0` and above) | No description given | _required_ |
     | `--range-c` | float range (`1` and below) | No description given | `0` |
+    | `--flag` / `--no-flag` | boolean | No description given | `False` |
     """
 ).strip()
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -89,12 +89,12 @@ HELLO_TABLE_EXPECTED = dedent(
     | Name | Type | Description | Default |
     | ------ | ---- | ----------- | ------- |
     | `-d`, `--debug` | text | Include debug output | _required_ |
-    | `--choice` | choice (`foo` &#x7C; `bar`) | No description given | `foo` |
-    | `--date` | datetime (`%Y-%m-%d`) | No description given | _required_ |
-    | `--range-a` | float range (between `0` and `1`) | No description given | `0` |
-    | `--range-b` | float range (`0` and above) | No description given | _required_ |
-    | `--range-c` | float range (`1` and below) | No description given | `0` |
-    | `--flag` / `--no-flag` | boolean | No description given | `False` |
+    | `--choice` | choice (`foo` &#x7C; `bar`) | N/A | `foo` |
+    | `--date` | datetime (`%Y-%m-%d`) | N/A | _required_ |
+    | `--range-a` | float range (between `0` and `1`) | N/A | `0` |
+    | `--range-b` | float range (`0` and above) | N/A | _required_ |
+    | `--range-c` | float range (`1` and below) | N/A | `0` |
+    | `--flag` / `--no-flag` | boolean | N/A | `False` |
     """
 ).strip()
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -28,7 +28,7 @@ HELLO_EXPECTED = dedent(
     hello [OPTIONS]
     ```
 
-    __Options:__
+    Options:
 
     ```
       -d, --debug TEXT  Include debug output
@@ -55,9 +55,9 @@ def test_prog_name():
 
 def test_make_command_docs_invalid():
     with pytest.raises(
-        ValueError, match="invalid is not a valid option style, which must be either 'plain' or 'table'."
+        MkDocsClickException, match="invalid is not a valid option style, which must be either 'plain' or 'table'."
     ):
-        "\n".join(make_command_docs("hello", hello, styles={"option": "invalid"})).strip()
+        "\n".join(make_command_docs("hello", hello, style="invalid")).strip()
 
 
 @click.command()
@@ -83,22 +83,22 @@ HELLO_TABLE_EXPECTED = dedent(
     hello-table [OPTIONS]
     ```
 
-    __Options:__
+    Options:
 
     | Name | Type | Description | Default |
     | ------ | ---- | ----------- | ------- |
-    | `-d`, `--debug` | TEXT | Include debug output | _required_ |
-    | `--choice` | CHOICE (`foo` &#x7C; `bar`) | No description given | `foo` |
-    | `--date` | DATETIME (`%Y-%m-%d`) | No description given | _required_ |
-    | `--range-a` | FLOAT RANGE (between `0` and `1`) | No description given | `0` |
-    | `--range-b` | FLOAT RANGE (`0` and above) | No description given | _required_ |
-    | `--range-c` | FLOAT RANGE (`1` and below) | No description given | `0` |
+    | `-d`, `--debug` | text | Include debug output | _required_ |
+    | `--choice` | choice (`foo` &#x7C; `bar`) | No description given | `foo` |
+    | `--date` | datetime (`%Y-%m-%d`) | No description given | _required_ |
+    | `--range-a` | float range (between `0` and `1`) | No description given | `0` |
+    | `--range-b` | float range (`0` and above) | No description given | _required_ |
+    | `--range-c` | float range (`1` and below) | No description given | `0` |
     """
 ).strip()
 
 
 def test_make_command_docs_table():
-    output = "\n".join(make_command_docs("hello", hello_table, styles={"option": "table"})).strip()
+    output = "\n".join(make_command_docs("hello", hello_table, style="table")).strip()
     assert output == HELLO_TABLE_EXPECTED
 
 
@@ -123,7 +123,7 @@ HELLO_ONLY_HELP_EXPECTED = dedent(
 
 
 def test_make_command_docs_only_help():
-    output = "\n".join(make_command_docs("hello", hello_only_help, styles={"option": "table"})).strip()
+    output = "\n".join(make_command_docs("hello", hello_only_help, style="table")).strip()
     assert output == HELLO_ONLY_HELP_EXPECTED
 
 
@@ -164,7 +164,7 @@ def test_custom_multicommand():
         multi hello [OPTIONS]
         ```
 
-        __Options:__
+        Options:
 
         ```
           -d, --debug TEXT  Include debug output

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -96,6 +96,7 @@ HELLO_TABLE_EXPECTED = dedent(
     | `--range-b` | float range (`0` and above) | N/A | _required_ |
     | `--range-c` | float range (`1` and below) | N/A | `0` |
     | `--flag` / `--no-flag` | boolean | N/A | `False` |
+    | `--help` | boolean | Show this message and exit. | `False` |
     """
 ).strip()
 
@@ -121,6 +122,12 @@ HELLO_ONLY_HELP_EXPECTED = dedent(
     ```
     hello-only-help [OPTIONS]
     ```
+
+    Options:
+
+    | Name | Type | Description | Default |
+    | ------ | ---- | ----------- | ------- |
+    | `--help` | boolean | Show this message and exit. | `False` |
     """
 ).strip()
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -55,7 +55,7 @@ def test_prog_name():
 
 def test_make_command_docs_invalid():
     with pytest.raises(
-        MkDocsClickException, match="invalid is not a valid option style, which must be either 'plain' or 'table'."
+        MkDocsClickException, match="invalid is not a valid option style, which must be either `plain` or `table`."
     ):
         "\n".join(make_command_docs("hello", hello, style="invalid")).strip()
 


### PR DESCRIPTION
Rewrite of #12 in a backward-compatible manner.

One difference from what @florimondmanca and I discussed is that I named the option `:option-style:`. This is more descriptive than `style` and easy to extend when we want to define styles for other sections such as usage.

Fix #11.