### PR TITLE
Keep --help as part of options raw output

### DIFF
--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -104,11 +104,15 @@ def _make_options(ctx: click.Context) -> Iterator[str]:
     """Create the Markdown lines describing the options for the command."""
     formatter = ctx.make_formatter()
     click.Command.format_options(ctx.command, ctx, formatter)
+
+    option_lines = formatter.getvalue().splitlines()
+
     # First line is redundant "Options"
-    # Last line is `--help`
-    option_lines = formatter.getvalue().splitlines()[1:-1]
-    if not option_lines:
-        return
+    option_lines = option_lines[1:]
+
+    if not option_lines:  # pragma: no cover
+        # We expect at least `--help` to be present.
+        raise RuntimeError("Expected at least one option")
 
     yield "Options:"
     yield ""

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -8,6 +8,12 @@ Usage:
 cli [OPTIONS] COMMAND [ARGS]...
 ```
 
+Options:
+
+```
+  --help  Show this message and exit.
+```
+
 ## bar
 
 The bar command
@@ -16,6 +22,12 @@ Usage:
 
 ```
 cli bar [OPTIONS] COMMAND [ARGS]...
+```
+
+Options:
+
+```
+  --help  Show this message and exit.
 ```
 
 ### hello
@@ -33,6 +45,7 @@ Options:
 ```
   --count INTEGER  Number of greetings.
   --name TEXT      The person to greet.
+  --help           Show this message and exit.
 ```
 
 ## foo
@@ -41,4 +54,10 @@ Usage:
 
 ```
 cli foo [OPTIONS]
+```
+
+Options:
+
+```
+  --help  Show this message and exit.
 ```

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -32,6 +32,7 @@ HELLO_EXPECTED = dedent(
 
     ```
       -d, --debug TEXT  Include debug output
+      --help            Show this message and exit.
     ```
 
     """
@@ -80,6 +81,12 @@ def test_custom_multicommand():
         multi [OPTIONS] COMMAND [ARGS]...
         ```
 
+        Options:
+
+        ```
+          --help  Show this message and exit.
+        ```
+
         ## hello
 
         Hello, world!
@@ -94,6 +101,7 @@ def test_custom_multicommand():
 
         ```
           -d, --debug TEXT  Include debug output
+          --help            Show this message and exit.
         ```
         """
     ).lstrip()


### PR DESCRIPTION
Closes #26 

Ensure `--help` is kept as part of the raw "Options" block. This means the block will be present for all commands.

This means simpler logic, which will help with implementing table output, refs #11.