### PR TITLE
Clean up table formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,13 @@ The syntax for `mkdocs-click` blocks is the following:
     :command: <COMMAND>
     :prog_name: <PROG_NAME>
     :depth: <DEPTH>
+    :style: <STYLE>
 ```
 
 Options:
 
-- `module`: path to the module where the command object is located.
-- `command`: name of the command object.
-- `prog_name`: _(Optional, default: same as `command`)_ the name to display for the command.
+- `module`: Path to the module where the command object is located.
+- `command`: Name of the command object.
+- `prog_name`: _(Optional, default: same as `command`)_ The name to display for the command.
 - `depth`: _(Optional, default: `0`)_ Offset to add when generating headers.
-- `style`: _(Optional, default: `plain`)_ style for the options section. The possible choices are `plain` and `table`.
+- `style`: _(Optional, default: `plain`)_ Style for the options section. The possible choices are `plain` and `table`.

--- a/mkdocs_click/_extension.py
+++ b/mkdocs_click/_extension.py
@@ -21,7 +21,7 @@ def replace_command_docs(**options: Any) -> Iterator[str]:
     command = options["command"]
     prog_name = options.get("prog_name", command)
     depth = int(options.get("depth", 0))
-    style = options.get("option-style", "plain")
+    style = options.get("style", "plain")
 
     command_obj = load_command(module, command)
 

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -88,7 +88,7 @@ HELLO_TABLE_EXPECTED = dedent(
     Options:
 
     | Name | Type | Description | Default |
-    | ------ | ---- | ----------- | ------- |
+    | ---- | ---- | ----------- | ------- |
     | `-d`, `--debug` | text | Include debug output | _required_ |
     | `--choice` | choice (`foo` &#x7C; `bar`) | N/A | `foo` |
     | `--date` | datetime (`%Y-%m-%d`) | N/A | _required_ |
@@ -107,11 +107,11 @@ def test_make_command_docs_table():
 
 
 @click.command()
-def hello_only_help():
+def hello_minimal():
     """Hello, world!"""
 
 
-HELLO_ONLY_HELP_EXPECTED = dedent(
+HELLO_TABLE_MINIMAL_EXPECTED = dedent(
     """
     # hello
 
@@ -120,21 +120,21 @@ HELLO_ONLY_HELP_EXPECTED = dedent(
     Usage:
 
     ```
-    hello-only-help [OPTIONS]
+    hello-minimal [OPTIONS]
     ```
 
     Options:
 
     | Name | Type | Description | Default |
-    | ------ | ---- | ----------- | ------- |
+    | ---- | ---- | ----------- | ------- |
     | `--help` | boolean | Show this message and exit. | `False` |
     """
 ).strip()
 
 
-def test_make_command_docs_only_help():
-    output = "\n".join(make_command_docs("hello", hello_only_help, style="table")).strip()
-    assert output == HELLO_ONLY_HELP_EXPECTED
+def test_make_command_docs_table_minimale():
+    output = "\n".join(make_command_docs("hello", hello_minimal, style="table")).strip()
+    assert output == HELLO_TABLE_MINIMAL_EXPECTED
 
 
 class MultiCLI(click.MultiCommand):


### PR DESCRIPTION
Follow-up for #25, refs #11

* Fix : `:option-style:` -> `:style:` for consistency with other option names.
* Fix: pass `style` to sub-commands (otherwise only top command would be formatted using the given `style`)
* Refactor table formatting logic using extra intermediary functions.
* Add a bunch of comments to help with readability and understanding of the code.
* Some other nits.