### PR TITLE
Make usage and options headings bold

### DIFF
--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -81,7 +81,7 @@ def _make_usage(ctx: click.Context) -> Iterator[str]:
     formatter.write_usage(ctx.command_path, " ".join(pieces), prefix="")
     usage = formatter.getvalue().rstrip("\n")
 
-    yield "Usage:"
+    yield "**Usage:**"
     yield ""
     yield "```"
     yield usage
@@ -114,7 +114,7 @@ def _make_plain_options(ctx: click.Context) -> Iterator[str]:
         # We expect at least `--help` to be present.
         raise RuntimeError("Expected at least one option")
 
-    yield "Options:"
+    yield "**Options:**"
     yield ""
     yield "```"
     yield from option_lines
@@ -193,7 +193,7 @@ def _make_table_options(ctx: click.Context) -> Iterator[str]:
     options = [param for param in ctx.command.get_params(ctx) if isinstance(param, click.Option)]
     option_rows = [_format_table_option_row(option) for option in options]
 
-    yield "Options:"
+    yield "**Options:**"
     yield ""
     yield "| Name | Type | Description | Default |"
     yield "| ---- | ---- | ----------- | ------- |"

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -2,13 +2,13 @@
 
 Main entrypoint for this dummy program
 
-Usage:
+**Usage:**
 
 ```
 cli [OPTIONS] COMMAND [ARGS]...
 ```
 
-Options:
+**Options:**
 
 ```
   --help  Show this message and exit.
@@ -18,13 +18,13 @@ Options:
 
 The bar command
 
-Usage:
+**Usage:**
 
 ```
 cli bar [OPTIONS] COMMAND [ARGS]...
 ```
 
-Options:
+**Options:**
 
 ```
   --help  Show this message and exit.
@@ -34,13 +34,13 @@ Options:
 
 Simple program that greets NAME for a total of COUNT times.
 
-Usage:
+**Usage:**
 
 ```
 cli bar hello [OPTIONS]
 ```
 
-Options:
+**Options:**
 
 ```
   --count INTEGER  Number of greetings.
@@ -50,13 +50,13 @@ Options:
 
 ## foo
 
-Usage:
+**Usage:**
 
 ```
 cli foo [OPTIONS]
 ```
 
-Options:
+**Options:**
 
 ```
   --help  Show this message and exit.

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -22,13 +22,13 @@ HELLO_EXPECTED = dedent(
 
     Hello, world!
 
-    Usage:
+    **Usage:**
 
     ```
     hello [OPTIONS]
     ```
 
-    Options:
+    **Options:**
 
     ```
       -d, --debug TEXT  Include debug output
@@ -79,13 +79,13 @@ HELLO_TABLE_EXPECTED = dedent(
 
     Hello, world!
 
-    Usage:
+    **Usage:**
 
     ```
     hello [OPTIONS]
     ```
 
-    Options:
+    **Options:**
 
     | Name | Type | Description | Default |
     | ---- | ---- | ----------- | ------- |
@@ -117,13 +117,13 @@ HELLO_TABLE_MINIMAL_EXPECTED = dedent(
 
     Hello, world!
 
-    Usage:
+    **Usage:**
 
     ```
     hello [OPTIONS]
     ```
 
-    Options:
+    **Options:**
 
     | Name | Type | Description | Default |
     | ---- | ---- | ----------- | ------- |
@@ -165,13 +165,13 @@ def test_custom_multicommand(multi):
 
         Multi help
 
-        Usage:
+        **Usage:**
 
         ```
         multi [OPTIONS] COMMAND [ARGS]...
         ```
 
-        Options:
+        **Options:**
 
         ```
           --help  Show this message and exit.
@@ -181,13 +181,13 @@ def test_custom_multicommand(multi):
 
         Hello, world!
 
-        Usage:
+        **Usage:**
 
         ```
         multi hello [OPTIONS]
         ```
 
-        Options:
+        **Options:**
 
         ```
           -d, --debug TEXT  Include debug output


### PR DESCRIPTION
Alternative to #14 

**Description**
Make "Usage" and "Options" headings for each command `**bold**`.

**Motivation**
Tweak legibility and navigation.

Before / After:

![Screenshot 2021-02-19 at 11 38 18](https://user-images.githubusercontent.com/15911462/108493946-3ccb6680-72a7-11eb-9919-8dc87bbb7515.png) ![Screenshot 2021-02-19 at 11 38 07](https://user-images.githubusercontent.com/15911462/108493958-40f78400-72a7-11eb-84e6-11a94dc8f9f3.png)
