### PR TITLE
Version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add table formatting. (Pulls #25, #30)
 - Use `:prog_name:` more consistently in usage. (Pull #24)
+- Allow using full command paths in headers. (Pull #36)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.3.0 - 2021-02-19
+
+### Changed
+
+- `--help` is now kept in options (it used to be automatically dropped). (Pull #29)
+
+### Added
+
+- Add table formatting. (Pulls #25, #30)
+- Use `:prog_name:` more consistently in usage. (Pull #24)
+
+### Fixed
+
+- Make usage and options headings bold to improve legibility. (Pull #31)
+
 ## 0.2.0 - 2020-12-09
 
 ### Added

--- a/mkdocs_click/__version__.py
+++ b/mkdocs_click/__version__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under the Apache license (see LICENSE)
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Changelog source: https://github.com/DataDog/mkdocs-click/compare/0.2.0...7b50e5d

## 0.3.0 - 2021-02-19

### Changed

- `--help` is now kept in options (it used to be automatically dropped). (Pull #29)

### Added

- Add table formatting. (Pulls #25, #30)
- Use `:prog_name:` more consistently in usage. (Pull #24)

### Fixed

- Make usage and options headings bold to improve legibility. (Pull #31)