### PR TITLE
Allow using full command paths in headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ If you are inserting documentation within other Markdown content, you can set th
 
 By default it is set to `0`, i.e. headers start at `<h1>`. If set to `1`, headers will start at `<h2>`, and so on. Note that if you insert your own first level heading and leave depth at its default value of 0, the page will have multiple `<h1>` tags, which is not compatible with themes that generate page-internal menus such as the ReadTheDocs and mkdocs-material themes.
 
+### Full command path headers
+
+By default, `mkdocs-click` outputs headers that contain the command name. For nested commands such as `$ cli build all`, this also means the heading would be `## all`. This might be surprising, and may be harder to navigate at a glance for highly nested CLI apps.
+
+If you'd like to show the full command path instead, turn on the [Attribute Lists extension](https://python-markdown.github.io/extensions/attr_list/):
+
+```yaml
+# mkdocs.yaml
+
+markdown_extensions:
+    - attr_list
+    - mkdocs-click
+```
+
+`mkdocs-click` will then output the full command path in headers (e.g. `## cli build all`) and permalinks (e.g. `#cli-build-all`).
+
+Note that the table of content (TOC) will still use the command name: the TOC is naturally hierarchal, so full command paths would be redundant. (This exception is why the `attr_list` extension is required.)
+
 ## Reference
 
 ### Block syntax

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,4 +6,5 @@ theme: readthedocs
 docs_dir: example
 
 markdown_extensions:
+  - attr_list
   - mkdocs-click

--- a/mkdocs_click/_extension.py
+++ b/mkdocs_click/_extension.py
@@ -4,6 +4,7 @@
 from typing import Any, Iterator, List
 
 from markdown.extensions import Extension
+from markdown.extensions.attr_list import AttrListExtension
 from markdown.preprocessors import Preprocessor
 
 from ._docs import make_command_docs
@@ -12,7 +13,7 @@ from ._loader import load_command
 from ._processing import replace_blocks
 
 
-def replace_command_docs(**options: Any) -> Iterator[str]:
+def replace_command_docs(has_attr_list: bool = False, **options: Any) -> Iterator[str]:
     for option in ("module", "command"):
         if option not in options:
             raise MkDocsClickException(f"Option {option!r} is required")
@@ -27,12 +28,24 @@ def replace_command_docs(**options: Any) -> Iterator[str]:
 
     prog_name = prog_name or command_obj.name or command
 
-    return make_command_docs(prog_name=prog_name, command=command_obj, depth=depth, style=style)
+    return make_command_docs(
+        prog_name=prog_name, command=command_obj, depth=depth, style=style, has_attr_list=has_attr_list
+    )
 
 
 class ClickProcessor(Preprocessor):
+    def __init__(self, md: Any) -> None:
+        super().__init__(md)
+        self._has_attr_list = any(isinstance(ext, AttrListExtension) for ext in md.registeredExtensions)
+
     def run(self, lines: List[str]) -> List[str]:
-        return list(replace_blocks(lines, title="mkdocs-click", replace=replace_command_docs))
+        return list(
+            replace_blocks(
+                lines,
+                title="mkdocs-click",
+                replace=lambda **options: replace_command_docs(has_attr_list=self._has_attr_list, **options),
+            )
+        )
 
 
 class MKClickExtension(Extension):
@@ -48,7 +61,7 @@ class MKClickExtension(Extension):
 
     def extendMarkdown(self, md: Any) -> None:
         md.registerExtension(self)
-        processor = ClickProcessor(md.parser)
+        processor = ClickProcessor(md)
         md.preprocessors.register(processor, "mk_click", 141)
 
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     python_requires=">=3.7",
     include_package_data=True,
     zip_safe=False,
-    entry_points={"markdown.extensions": ["mkdocs-click = mkdocs_click:MKClickExtension"]},
+    entry_points={"markdown.extensions": ["mkdocs-click = mkdocs_click:makeExtension"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     python_requires=">=3.7",
     include_package_data=True,
     zip_safe=False,
-    entry_points={"markdown.extensions": ["mkdocs-click = mkdocs_click:makeExtension"]},
+    entry_points={"markdown.extensions": ["mkdocs-click = mkdocs_click:MKClickExtension"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/tests/app/expected-enhanced.md
+++ b/tests/app/expected-enhanced.md
@@ -1,0 +1,63 @@
+# cli { #cli data-toc-label="cli" }
+
+Main entrypoint for this dummy program
+
+**Usage:**
+
+```
+cli [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options:**
+
+```
+  --help  Show this message and exit.
+```
+
+## cli bar { #cli-bar data-toc-label="bar" }
+
+The bar command
+
+**Usage:**
+
+```
+cli bar [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options:**
+
+```
+  --help  Show this message and exit.
+```
+
+### cli bar hello { #cli-bar-hello data-toc-label="hello" }
+
+Simple program that greets NAME for a total of COUNT times.
+
+**Usage:**
+
+```
+cli bar hello [OPTIONS]
+```
+
+**Options:**
+
+```
+  --count INTEGER  Number of greetings.
+  --name TEXT      The person to greet.
+  --help           Show this message and exit.
+```
+
+## cli foo { #cli-foo data-toc-label="foo" }
+
+**Usage:**
+
+```
+cli foo [OPTIONS]
+```
+
+**Options:**
+
+```
+  --help  Show this message and exit.
+```

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 import pytest
 from markdown import Markdown
 
-from mkdocs_click._exceptions import MkDocsClickException
+import mkdocs_click
 
 EXPECTED = (Path(__file__).parent / "app" / "expected.md").read_text()
 EXPECTED_ENHANCED = (Path(__file__).parent / "app" / "expected-enhanced.md").read_text()
@@ -26,7 +26,7 @@ def test_extension(command, expected_name):
     """
     Markdown output for a relatively complex Click application is correct.
     """
-    md = Markdown(extensions=['mkdocs-click'])
+    md = Markdown(extensions=[mkdocs_click.makeExtension()])
 
     source = dedent(
         f"""
@@ -45,7 +45,7 @@ def test_prog_name():
     """
     The :prog_name: attribute determines the name to display for the command.
     """
-    md = Markdown(extensions=['mkdocs-click'])
+    md = Markdown(extensions=[mkdocs_click.makeExtension()])
 
     source = dedent(
         """
@@ -65,7 +65,7 @@ def test_depth():
     """
     The :depth: attribute increases the level of headers.
     """
-    md = Markdown(extensions=['mkdocs-click'])
+    md = Markdown(extensions=[mkdocs_click.makeExtension()])
 
     source = dedent(
         """
@@ -88,7 +88,7 @@ def test_required_options(option):
     """
     The module and command options are required.
     """
-    md = Markdown(extensions=['mkdocs-click'])
+    md = Markdown(extensions=[mkdocs_click.makeExtension()])
 
     source = dedent(
         """
@@ -100,7 +100,7 @@ def test_required_options(option):
 
     source = source.replace(f":{option}:", ":somethingelse:")
 
-    with pytest.raises(MkDocsClickException):
+    with pytest.raises(mkdocs_click.MkDocsClickException):
         md.convert(source)
 
 
@@ -111,7 +111,9 @@ def test_enhanced_titles():
     See: https://github.com/DataDog/mkdocs-click/issues/35
     """
     md = Markdown(extensions=['attr_list'])
-    md.registerExtensions(['mkdocs-click'], {})
+    # Register our extension as a second step, so that we see `attr_list`.
+    # This is what MkDocs does, so there's no hidden usage constraint here.
+    md.registerExtensions([mkdocs_click.makeExtension()], {})
 
     source = dedent(
         """

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -110,7 +110,7 @@ def test_enhanced_titles():
 
     See: https://github.com/DataDog/mkdocs-click/issues/35
     """
-    md = Markdown(extensions=['attr_list'])
+    md = Markdown(extensions=["attr_list"])
     # Register our extension as a second step, so that we see `attr_list`.
     # This is what MkDocs does, so there's no hidden usage constraint here.
     md.registerExtensions([mkdocs_click.makeExtension()], {})

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7,9 +7,10 @@ from textwrap import dedent
 import pytest
 from markdown import Markdown
 
-import mkdocs_click
+from mkdocs_click._exceptions import MkDocsClickException
 
 EXPECTED = (Path(__file__).parent / "app" / "expected.md").read_text()
+EXPECTED_ENHANCED = (Path(__file__).parent / "app" / "expected-enhanced.md").read_text()
 
 
 @pytest.mark.parametrize(
@@ -25,7 +26,7 @@ def test_extension(command, expected_name):
     """
     Markdown output for a relatively complex Click application is correct.
     """
-    md = Markdown(extensions=[mkdocs_click.makeExtension()])
+    md = Markdown(extensions=['mkdocs-click'])
 
     source = dedent(
         f"""
@@ -44,7 +45,7 @@ def test_prog_name():
     """
     The :prog_name: attribute determines the name to display for the command.
     """
-    md = Markdown(extensions=[mkdocs_click.makeExtension()])
+    md = Markdown(extensions=['mkdocs-click'])
 
     source = dedent(
         """
@@ -64,7 +65,7 @@ def test_depth():
     """
     The :depth: attribute increases the level of headers.
     """
-    md = Markdown(extensions=[mkdocs_click.makeExtension()])
+    md = Markdown(extensions=['mkdocs-click'])
 
     source = dedent(
         """
@@ -87,7 +88,7 @@ def test_required_options(option):
     """
     The module and command options are required.
     """
-    md = Markdown(extensions=[mkdocs_click.makeExtension()])
+    md = Markdown(extensions=['mkdocs-click'])
 
     source = dedent(
         """
@@ -99,5 +100,25 @@ def test_required_options(option):
 
     source = source.replace(f":{option}:", ":somethingelse:")
 
-    with pytest.raises(mkdocs_click.MkDocsClickException):
+    with pytest.raises(MkDocsClickException):
         md.convert(source)
+
+
+def test_enhanced_titles():
+    """
+    If `attr_list` extension is registered, section titles are enhanced with full command paths.
+
+    See: https://github.com/DataDog/mkdocs-click/issues/35
+    """
+    md = Markdown(extensions=['attr_list'])
+    md.registerExtensions(['mkdocs-click'], {})
+
+    source = dedent(
+        """
+        ::: mkdocs-click
+            :module: tests.app.cli
+            :command: cli
+        """
+    )
+
+    assert md.convert(source) == md.convert(EXPECTED_ENHANCED)


### PR DESCRIPTION
Closes #35 

## Description
Allows progressively enhancing rendering to output full command paths, instead of only command names.

The only change is that headers show eg `ddev env ls` instead of `ls`, and permalinks are eg `#ddev-env-ls` instead of `#ls`.

We need the `attr_list` extension to be installed, so to bring this change progressively we check for the extension instead of making it a hard-requirement, and keep the old behavior as a fallback (AKA progressive enhancement). This does take a bit of additional code.

For cases when `attr_list` is already present, I think this behavior is better in any case, so no need for a "force-disable" flag.

## Preview

![before](https://user-images.githubusercontent.com/15911462/108516960-1cab9f80-72c7-11eb-9e14-07dc3f673c18.png) ![after](https://user-images.githubusercontent.com/15911462/108516961-1cab9f80-72c7-11eb-8e6b-204989482783.png)
