### PR TITLE
Correctly handle default values of `None`

### DIFF
--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -221,7 +221,8 @@ def _format_table_option_row(option: click.Option) -> str:
     description = option.help if option.help is not None else "N/A"
 
     # -> `False`
-    default = f"`{option.default}`" if option.default is not None else "_required_"
+    none_default_msg = "_required" if option.required else "None"
+    default = f"`{option.default}`" if option.default is not None else none_default_msg
 
     # -> "| `-V`, `--version` / `--show-version` | boolean | Show version info. | `False` |"
     return f"| {names} | {value_type} | {description} | {default} |"


### PR DESCRIPTION
Options with None as default value are not handled correctly.
This PR fixes the issue.

e.g.
```python
@click.option("-m", "--message", required=False, default=None)
```

## Before
![Screenshot from 2021-08-05 08-47-51](https://user-images.githubusercontent.com/2062128/128269715-602ab04e-1903-4690-8fe1-5307c421cd73.png)

## After
![Screenshot from 2021-08-05 08-46-08](https://user-images.githubusercontent.com/2062128/128269653-c74b2581-c712-4c5d-bdff-e4f098ad21f5.png)
