### PR TITLE
Add `show_hidden` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ Options:
 - `depth`: _(Optional, default: `0`)_ Offset to add when generating headers.
 - `style`: _(Optional, default: `plain`)_ Style for the options section. The possible choices are `plain` and `table`.
 - `remove_ascii_art`: _(Optional, default: `False`)_ When docstrings begin with the escape character `\b`, all text will be ignored until the next blank line is encountered.
+- `show_hidden`: _(Optional, default: `False`)_ Show commands and options that are marked as hidden.

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -22,7 +22,13 @@ def make_command_docs(
 ) -> Iterator[str]:
     """Create the Markdown lines for a command and its sub-commands."""
     for line in _recursively_make_command_docs(
-        prog_name, command, depth=depth, style=style, remove_ascii_art=remove_ascii_art, show_hidden=show_hidden, has_attr_list=has_attr_list
+        prog_name,
+        command,
+        depth=depth,
+        style=style,
+        remove_ascii_art=remove_ascii_art,
+        show_hidden=show_hidden,
+        has_attr_list=has_attr_list,
     ):
         if line.strip() == "\b":
             continue
@@ -55,7 +61,13 @@ def _recursively_make_command_docs(
 
     for command in sorted(subcommands, key=lambda cmd: cmd.name):  # type: ignore
         yield from _recursively_make_command_docs(
-            cast(str, command.name), command, parent=ctx, depth=depth + 1, style=style, show_hidden=show_hidden, has_attr_list=has_attr_list
+            cast(str, command.name),
+            command,
+            parent=ctx,
+            depth=depth + 1,
+            style=style,
+            show_hidden=show_hidden,
+            has_attr_list=has_attr_list,
         )
 
 

--- a/mkdocs_click/_extension.py
+++ b/mkdocs_click/_extension.py
@@ -24,6 +24,7 @@ def replace_command_docs(has_attr_list: bool = False, **options: Any) -> Iterato
     depth = int(options.get("depth", 0))
     style = options.get("style", "plain")
     remove_ascii_art = options.get("remove_ascii_art", False)
+    show_hidden = options.get("show_hidden", False)
 
     command_obj = load_command(module, command)
 
@@ -35,6 +36,7 @@ def replace_command_docs(has_attr_list: bool = False, **options: Any) -> Iterato
         depth=depth,
         style=style,
         remove_ascii_art=remove_ascii_art,
+        show_hidden=show_hidden,
         has_attr_list=has_attr_list,
     )
 

--- a/tests/app/cli.py
+++ b/tests/app/cli.py
@@ -9,7 +9,8 @@ NOT_A_COMMAND = "not-a-command"
 @click.command()
 @click.option("--count", default=1, help="Number of greetings.")
 @click.option("--name", prompt="Your name", help="The person to greet.")
-def hello(count, name):
+@click.option("--hidden", hidden=True)
+def hello(count, name, hidden):
     """Simple program that greets NAME for a total of COUNT times."""
 
 
@@ -33,13 +34,20 @@ def bar():
     """The bar command"""
 
 
+@click.command(hidden=True)
+def hidden():
+    """The hidden command"""
+
+
 bar.add_command(hello)
 
 cli.add_command(foo)
 cli.add_command(bar)
+cli.add_command(hidden)
 
 cli_named.add_command(foo)
 cli_named.add_command(bar)
+cli_named.add_command(hidden)
 
 
 class MultiCLI(click.MultiCommand):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -231,3 +231,39 @@ def test_custom_multicommand(multi):
 
     output = "\n".join(make_command_docs("multi", multi))
     assert output == expected
+
+
+@pytest.mark.parametrize("show_hidden", [True, False])
+@pytest.mark.parametrize("style", ["plain", "table"])
+def test_show_hidden_option(show_hidden, style):
+    @click.command()
+    @click.option("--hidden", hidden=True)
+    def _test_cmd(hidden):
+        """Test cmd."""
+
+    output = "\n".join(make_command_docs("_test_cmd", _test_cmd, style=style, show_hidden=show_hidden))
+    assert ("--hidden" in output) == show_hidden
+
+
+@pytest.mark.parametrize("show_hidden", [True, False])
+def test_show_hidden_command(show_hidden):
+    @click.command(hidden=True)
+    def _test_cmd():
+        """Test cmd."""
+
+    output = "\n".join(make_command_docs("_test_cmd", _test_cmd, show_hidden=show_hidden))
+    assert (output != "") == show_hidden
+
+
+@pytest.mark.parametrize("show_hidden", [True, False])
+def test_show_hidden_group(show_hidden):
+    @click.group(hidden=True)
+    def _test_group():
+        """Test group."""
+
+    @_test_group.command(hidden=False)
+    def _test_cmd():
+        """Test cmd."""
+
+    output = "\n".join(make_command_docs("_test_group", _test_group, show_hidden=show_hidden))
+    assert (output != "") == show_hidden

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under the Apache license (see LICENSE)
 from textwrap import dedent
+from typing import cast
 
 import click
 import pytest
 
-from mkdocs_click._docs import make_command_docs
+from mkdocs_click._docs import make_command_docs, _show_options
 from mkdocs_click._exceptions import MkDocsClickException
 
 
@@ -267,3 +268,25 @@ def test_show_hidden_group(show_hidden):
 
     output = "\n".join(make_command_docs("_test_group", _test_group, show_hidden=show_hidden))
     assert (output != "") == show_hidden
+
+
+def test_show_options():
+    @click.command()
+    @click.option("--hidden", hidden=True)
+    @click.option("--normal", hidden=False)
+    def _test_cmd(hidden, normal):
+        """Test cmd."""
+
+    ctx = click.Context(cast(click.Command, _test_cmd), info_name="_test_cmd")
+    opt_hidden = cast(click.Option, ctx.command.params[0])
+    opt_normal = cast(click.Option, ctx.command.params[1])
+
+    assert opt_hidden.hidden
+    assert not opt_normal.hidden
+
+    with _show_options(ctx):
+        assert not opt_hidden.hidden
+        assert not opt_normal.hidden
+
+    assert opt_hidden.hidden
+    assert not opt_normal.hidden


### PR DESCRIPTION
Resolves #51 

The changes are rather simple, except the `_make_plain_options()` where I had to hack it a bit to make Click's formatter notice hidden options.