### PR TITLE
Add link to subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,5 @@ Options:
 - `style`: _(Optional, default: `plain`)_ Style for the options section. The possible choices are `plain` and `table`.
 - `remove_ascii_art`: _(Optional, default: `False`)_ When docstrings begin with the escape character `\b`, all text will be ignored until the next blank line is encountered.
 - `show_hidden`: _(Optional, default: `False`)_ Show commands and options that are marked as hidden.
+- `list_subcommands`: _(Optional, default: `True`)_ List subcommands of a given command. If _attr_list_ is installed,
+add links to subcommands also.

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -3,7 +3,7 @@
 # Licensed under the Apache license (see LICENSE)
 import inspect
 from contextlib import contextmanager, ExitStack
-from typing import Iterator, List, cast
+from typing import Iterator, List, cast, Optional
 
 import click
 from markdown.extensions.toc import slugify
@@ -18,6 +18,7 @@ def make_command_docs(
     style: str = "plain",
     remove_ascii_art: bool = False,
     show_hidden: bool = False,
+    list_subcommands: bool = True,
     has_attr_list: bool = False,
 ) -> Iterator[str]:
     """Create the Markdown lines for a command and its sub-commands."""
@@ -28,6 +29,7 @@ def make_command_docs(
         style=style,
         remove_ascii_art=remove_ascii_art,
         show_hidden=show_hidden,
+        list_subcommands=list_subcommands,
         has_attr_list=has_attr_list,
     ):
         if line.strip() == "\b":
@@ -44,10 +46,11 @@ def _recursively_make_command_docs(
     style: str = "plain",
     remove_ascii_art: bool = False,
     show_hidden: bool = False,
+    list_subcommands: bool = True,
     has_attr_list: bool = False,
 ) -> Iterator[str]:
     """Create the raw Markdown lines for a command and its sub-commands."""
-    ctx = click.Context(cast(click.Command, command), info_name=prog_name, parent=parent)
+    ctx = _build_command_context(prog_name=prog_name, command=command, parent=parent)
 
     if ctx.command.hidden and not show_hidden:
         return
@@ -58,8 +61,15 @@ def _recursively_make_command_docs(
     yield from _make_options(ctx, style, show_hidden=show_hidden)
 
     subcommands = _get_sub_commands(ctx.command, ctx)
+    if len(subcommands) == 0:
+        return
 
-    for command in sorted(subcommands, key=lambda cmd: cmd.name):  # type: ignore
+    subcommands.sort(key=lambda cmd: cmd.name)
+
+    if list_subcommands:
+        yield from _make_subcommands_links(subcommands, ctx, has_attr_list=has_attr_list)
+
+    for command in subcommands:
         yield from _recursively_make_command_docs(
             cast(str, command.name),
             command,
@@ -71,11 +81,15 @@ def _recursively_make_command_docs(
         )
 
 
+def _build_command_context(prog_name: str, command: click.BaseCommand, parent: Optional[click.Context]):
+    return click.Context(cast(click.Command, command), info_name=prog_name, parent=parent)
+
+
 def _get_sub_commands(command: click.Command, ctx: click.Context) -> List[click.Command]:
     """Return subcommands of a Click command."""
     subcommands = getattr(command, "commands", {})
     if subcommands:
-        return subcommands.values()  # type: ignore
+        return list(subcommands.values())
 
     if not isinstance(command, click.MultiCommand):
         return []
@@ -131,26 +145,30 @@ def _make_description(ctx: click.Context, remove_ascii_art: bool = False) -> Ite
     """Create markdown lines based on the command's own description."""
     help_string = ctx.command.help or ctx.command.short_help
 
-    if help_string:
-        # https://github.com/pallets/click/pull/2151
-        help_string = inspect.cleandoc(help_string)
+    if not help_string:
+        return
 
-        if remove_ascii_art:
-            skipped_ascii_art = True
-            for i, line in enumerate(help_string.splitlines()):
-                if skipped_ascii_art is False:
-                    if not line.strip():
-                        skipped_ascii_art = True
-                        continue
-                elif i == 0 and line.strip() == "\b":
-                    skipped_ascii_art = False
+    # https://github.com/pallets/click/pull/2151
+    help_string = inspect.cleandoc(help_string)
 
-                if skipped_ascii_art:
-                    yield line
-        else:
-            yield from help_string.splitlines()
-
+    if not remove_ascii_art:
+        yield from help_string.splitlines()
         yield ""
+        return
+
+    skipped_ascii_art = True
+    for i, line in enumerate(help_string.splitlines()):
+        if skipped_ascii_art is False:
+            if not line.strip():
+                skipped_ascii_art = True
+                continue
+        elif i == 0 and line.strip() == "\b":
+            skipped_ascii_art = False
+
+        if skipped_ascii_art:
+            yield line
+    yield ""
+
 
 
 def _make_usage(ctx: click.Context) -> Iterator[str]:
@@ -299,4 +317,25 @@ def _make_table_options(ctx: click.Context, show_hidden: bool = False) -> Iterat
     yield "| Name | Type | Description | Default |"
     yield "| ---- | ---- | ----------- | ------- |"
     yield from option_rows
+    yield ""
+
+
+def _make_subcommands_links(
+    subcommands: List[click.BaseCommand],
+    parent: click.Context,
+    has_attr_list: bool
+):
+
+    yield "**Subcommands**"
+    yield ""
+    for command in subcommands:
+        command_name = cast(str, command.name)
+        ctx = _build_command_context(command_name, command, parent)
+        command_bullet = (
+            command_name
+            if not has_attr_list
+            else f"[{command_name}](#{slugify(ctx.command_path, '-')})"
+        )
+        help_string = ctx.command.short_help or ctx.command.help.splitlines()[0]
+        yield f"- *{command_bullet}*: {help_string}"
     yield ""

--- a/mkdocs_click/_extension.py
+++ b/mkdocs_click/_extension.py
@@ -25,6 +25,7 @@ def replace_command_docs(has_attr_list: bool = False, **options: Any) -> Iterato
     style = options.get("style", "plain")
     remove_ascii_art = options.get("remove_ascii_art", False)
     show_hidden = options.get("show_hidden", False)
+    list_subcommands = options.get("list_subcommands", False)
 
     command_obj = load_command(module, command)
 
@@ -37,6 +38,7 @@ def replace_command_docs(has_attr_list: bool = False, **options: Any) -> Iterato
         style=style,
         remove_ascii_art=remove_ascii_art,
         show_hidden=show_hidden,
+        list_subcommands=list_subcommands,
         has_attr_list=has_attr_list,
     )
 

--- a/tests/app/expected-enhanced.md
+++ b/tests/app/expected-enhanced.md
@@ -30,6 +30,10 @@ cli bar [OPTIONS] COMMAND [ARGS]...
   --help  Show this message and exit.
 ```
 
+**Subcommands**
+
+- *[hello](#cli-bar-hello)*: Simple program that greets NAME for a total of COUNT times.
+
 ### cli bar hello { #cli-bar-hello data-toc-label="hello" }
 
 Simple program that greets NAME for a total of COUNT times.

--- a/tests/app/expected.md
+++ b/tests/app/expected.md
@@ -30,6 +30,10 @@ cli bar [OPTIONS] COMMAND [ARGS]...
   --help  Show this message and exit.
 ```
 
+**Subcommands**
+
+- *hello*: Simple program that greets NAME for a total of COUNT times.
+
 ### hello
 
 Simple program that greets NAME for a total of COUNT times.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -211,6 +211,10 @@ def test_custom_multicommand(multi):
           --help  Show this message and exit.
         ```
 
+        **Subcommands**
+ 
+        - *hello*: Hello, world!
+
         ## hello
 
         Hello, world!


### PR DESCRIPTION
# Description
When documenting a group or multicommand using *mkdocs-click*, added a new section elaborating the subcommands with links to full documentation:
<img width="347" alt="Untitled" src="https://user-images.githubusercontent.com/19425795/173587861-2aeaead3-b37a-4a4e-8487-231463fe4d16.png">

This new ability can be disabled using `list_subcommands` to False. True by default
