### PR TITLE
Use an API token to publish to PyPi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,5 +23,5 @@ jobs:
       - name: "Publish to PyPI"
         run: scripts/publish
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Motivation: https://datadoghq.atlassian.net/browse/SINT-948

I do not have the permission to add new secrets to this project so I can't add the token myself. 