### PR TITLE
Properly trim whitespace from the usage string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Remove explicit reference to `click.BaseCommand` and `click.MultiCommand` objects in anticipation of their deprecation. (Pull #82)
+- Properly ensure whitespace is trimmed from the usage string. (Pull #83)
 
 ## 0.8.1 - 2023-09-18
 

--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -193,7 +193,7 @@ def _make_usage(ctx: click.Context) -> Iterator[str]:
     formatter = ctx.make_formatter()
     pieces = ctx.command.collect_usage_pieces(ctx)
     formatter.write_usage(ctx.command_path, " ".join(pieces), prefix="")
-    usage = formatter.getvalue().rstrip("\n")
+    usage = formatter.getvalue().strip()
 
     yield "**Usage:**"
     yield ""


### PR DESCRIPTION
It's possible for formatter subclasses to have leading whitespace as I noticed when doing this PR: https://github.com/ewels/rich-click/pull/230