### PR TITLE
Fix usage and options generation

### DIFF
--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -96,7 +96,7 @@ def _build_command_context(
     prog_name: str, command: click.Command, parent: click.Context | None
 ) -> click.Context:
     # https://github.com/pallets/click/blob/8.1.8/src/click/core.py#L859-L862
-    return command.context_class(
+    return click.Context(
         cast(click.Command, command),
         info_name=prog_name,
         parent=parent,


### PR DESCRIPTION
The usage and the option with the default style "plain" are not rendered into the webpage but rather displayed in the shell running `mkdocs serve`

Happening since this commit: a614ab60b2f44ff5faa6d9c6554e6a857dacef5c which did switch from `click.Context()` to `command.context_class`.

- https://click.palletsprojects.com/en/stable/api/#click.Context
- https://click.palletsprojects.com/en/stable/api/#click.BaseCommand.context_class

says it’s an "alias of Context", but it behaves differently


## Without the fix
Empty usage and options.

![Screenshot From 2025-04-13 11-06-11](https://github.com/user-attachments/assets/d8dc6a59-b23b-4bf4-8029-2282e5f560ac)

They are  instead displayed in `mkdocs serve` shell.

```
poetry run mkdocs serve
INFO    -  Building documentation...
INFO    -  Cleaning site directory
                                                                                                                                                                                                                                             
  silkaj [OPTIONS] COMMAND [ARGS]...                                                                                                                                                                                                         
                                                                                                                                                                                                                                             
Options:

  -h, --help
            
Show this message and exit.

  -v, --version         
```

## With the fix
Correct generation of the webpage with usage and options fields filled. Not displayed in `mkdocs serve` shell.

![Screenshot From 2025-04-13 11-06-44](https://github.com/user-attachments/assets/6d83338a-036d-43e9-8d87-d39a0ffa89c1)