### PR TITLE
Skip rest of description if `\f` marker is encountered

### DIFF
--- a/mkdocs_click/_docs.py
+++ b/mkdocs_click/_docs.py
@@ -174,6 +174,10 @@ def _make_description(ctx: click.Context, remove_ascii_art: bool = False) -> Ite
     # https://github.com/pallets/click/pull/2151
     help_string = inspect.cleandoc(help_string)
 
+    # Skip rest of the description if the `\f` marker is found as per Click's documentation.
+    # https://click.palletsprojects.com/en/stable/documentation/#truncating-help-texts
+    help_string = help_string.partition("\f")[0]
+
     if not remove_ascii_art:
         yield from help_string.splitlines()
         yield ""

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -28,6 +28,27 @@ def hello_escape_marker():
 
 @click.command()
 @click.option("-d", "--debug", help="Include debug output")
+def hello_truncating_escape_marker():
+    """
+    Hello, world!\f
+
+    Hidden world.
+    """
+
+
+@click.command()
+@click.option("-d", "--debug", help="Include debug output")
+def hello_truncating_escape_marker_on_new_line():
+    """
+    Hello, world!
+    \f
+
+    Hidden world.
+    """
+
+
+@click.command()
+@click.option("-d", "--debug", help="Include debug output")
 def hello_ascii_art():
     """
     \b
@@ -111,6 +132,16 @@ def test_style_invalid():
 
 def test_basic_escape_marker():
     output = "\n".join(make_command_docs("hello", hello_escape_marker))
+    assert output == HELLO_EXPECTED
+
+
+def test_truncating_escape_marker():
+    output = "\n".join(make_command_docs("hello", hello_truncating_escape_marker))
+    assert output == HELLO_EXPECTED
+
+
+def test_truncating_escape_marker_on_new_line():
+    output = "\n".join(make_command_docs("hello", hello_truncating_escape_marker_on_new_line))
     assert output == HELLO_EXPECTED
 
 


### PR DESCRIPTION
This PR partly addresses https://github.com/mkdocs/mkdocs-click/issues/59.

Click's implementation can be found here: https://github.com/pallets/click/blob/main/src/click/core.py#L1111